### PR TITLE
문서: auth 모듈 의존성 명시

### DIFF
--- a/CONTRACT_SYNC.md
+++ b/CONTRACT_SYNC.md
@@ -3,15 +3,27 @@
 - Contract Source: https://github.com/jho951/contract
 - Service SoT Branch: `main`
 - Contract Role: Authentication/session/token owner
+- Responsibility Split: auth-service authenticates, authz-service owns capability truth, user-service owns visibility/privacy
 
 ## Required Links
-- Routing: https://github.com/jho951/contract/blob/main/contracts/routing.md
-- Security: https://github.com/jho951/contract/blob/main/contracts/security.md
-- Env: https://github.com/jho951/contract/blob/main/contracts/env.md
+- Common README: https://github.com/jho951/contract/blob/main/contracts/common/README.md
+- Routing: https://github.com/jho951/contract/blob/main/contracts/common/routing.md
+- Security: https://github.com/jho951/contract/blob/main/contracts/common/security.md
+- Env: https://github.com/jho951/contract/blob/main/contracts/common/env.md
+- Auth README: https://github.com/jho951/contract/blob/main/contracts/auth/README.md
+- Auth v2: https://github.com/jho951/contract/blob/main/contracts/auth/v2.md
+- Auth OpenAPI v2: https://github.com/jho951/contract/blob/main/contracts/openapi/auth-service.v2.yaml
+- Authz README: https://github.com/jho951/contract/blob/main/contracts/authz/README.md
+- Authz v2: https://github.com/jho951/contract/blob/main/contracts/authz/v2.md
+- Authz OpenAPI v2: https://github.com/jho951/contract/blob/main/contracts/openapi/authz-service.v2.yaml
 - User OpenAPI: https://github.com/jho951/contract/blob/main/contracts/openapi/user-service.v1.yaml
+- User Visibility: https://github.com/jho951/contract/blob/main/contracts/user/visibility.md
 
 ## Sync Checklist
 - [ ] `USER_SERVICE_BASE_URL` uses service DNS (`http://user-service:8082`)
 - [ ] internal JWT claims (`iss/aud/scope`) match contract
+- [ ] SSO provider and MFA step-up behavior match `contracts/auth/v2.md`
+- [ ] authz snapshots/claims emitted by auth align with `contracts/authz/v2.md`
 - [ ] user provisioning uses contract-defined endpoints
+- [ ] visibility/privacy policy remains owned by user-service, not auth-service
 - [ ] gateway-facing auth behavior documented by contract

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@
   - `common`: 공통 설정/응답/로깅 모듈
 - Docker 네트워크 구조
   - `SERVICE_SHARED_NETWORK`(external): gateway/auth/user-service 간 서비스 통신용 공유 네트워크
-    - 기본값: `msa-service-shared`
+    - 기본값: `service-backbone-shared`
   - `auth-private`(internal): auth-service와 auth-mysql 전용 private 네트워크
-  - `redis-core`(external): 중앙 Redis 네트워크
+  - `service-backbone-shared`(external): 중앙 Redis 및 서비스 간 공유 네트워크
 
 ## 실행 가이드
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ export REDIS_SSL=false
 - 감사 로그 테이블 `auth_audit_logs` 는 제거되었고 현재 코드에서 사용하지 않습니다.
 - `dev` 프로필은 JPA `ddl-auto: create` 로 애플리케이션 시작 시 스키마를 생성합니다.
 - `prod` 프로필은 JPA `ddl-auto: none` 이므로 스키마를 사전에 준비해야 합니다.
-- 운영 DB 수동 마이그레이션 예시는 `db/migrations/2026-03-27_drop_auth_social_accounts.sql` 및 `scripts/db/apply-drop-auth-social-accounts-prod.sh`를 참고하면 됩니다.
+- UUID 식별자는 코드와 DB 모두 `CHAR(36)` 바인딩을 사용합니다.
+- 운영 DB가 이전 `BINARY(16)` 스키마라면 `db/migrations/2026-03-31_bind_uuid_columns_char36.sql` 및 `scripts/db/apply-bind-uuid-char36-prod.sh`를 먼저 적용해야 합니다.
+- 과거 소셜 계정 제거용 마이그레이션이 필요하면 `db/migrations/2026-03-27_drop_auth_social_accounts.sql` 및 `scripts/db/apply-drop-auth-social-accounts-prod.sh`를 참고하면 됩니다.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - 공통 계약 레포: `https://github.com/jho951/contract`
 - 이 서비스의 코드 SoT: `Auth-server` `main`
 - 인터페이스 변경 시 본 저장소 구현보다 계약 레포 변경을 먼저 반영합니다.
+- 책임 분리: `Auth-server`는 인증/세션/토큰, `Authz-server`는 capability 진실, `User-server`는 프로필 공개 범위를 소유합니다.
 
 ## Architecture
 
@@ -114,6 +115,7 @@ export REDIS_SSL=false
 
 - 서비스 책임 분리와 `user-service` 설계안은 [docs/auth-user-service-design.md](./docs/auth-user-service-design.md) 문서를 참고하면 됩니다.
 - 현재 구조에서 `auth-service` 는 인증 컨텍스트를 만들고, `user-service` 는 사용자 마스터 데이터를 소유합니다. SSO 로그인 완료 시 `auth-service` 는 `USER_SERVICE_BASE_URL` 을 통해 `user-service` 를 호출합니다.
+- 권한 보유 사실의 공개 여부는 auth-service가 아닌 user-service privacy/visibility 정책에서 다룹니다.
 - DB 스키마와 환경별 생성 정책은 [docs/database.md](./docs/database.md) 문서를 참고하면 됩니다.
 - 현재 Gradle 루트는 멀티모듈 집계 프로젝트이며, `app`과 `common` 모듈로 구성됩니다.
 - Docker 환경 값의 단일 소스는 루트 `.env.dev`/`.env.prod`입니다.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - refresh rotation
   - logout
   - cookie/session + access token authentication
+- 현재 구현은 외부 `auth` 모듈을 통해 인증 원천과 세션 발급 흐름을 구성한다.
 - `app stack`
   - `mysql`
   - external `redis`

--- a/app/src/main/java/com/authservice/app/domain/auth/entity/Auth.java
+++ b/app/src/main/java/com/authservice/app/domain/auth/entity/Auth.java
@@ -13,6 +13,8 @@ import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "auth_accounts")
@@ -22,10 +24,12 @@ public class Auth {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
-	@Column(name = "id", nullable = false, updatable = false, columnDefinition = "BINARY(16)")
+	@Column(name = "id", nullable = false, updatable = false, columnDefinition = "char(36)")
+	@JdbcTypeCode(SqlTypes.CHAR)
 	private UUID id;
 
-	@Column(name = "user_id", nullable = false, unique = true, columnDefinition = "BINARY(16)")
+	@Column(name = "user_id", nullable = false, unique = true, columnDefinition = "char(36)")
+	@JdbcTypeCode(SqlTypes.CHAR)
 	private UUID userId;
 
 	@Column(name = "login_id", nullable = false, unique = true)

--- a/app/src/main/java/com/authservice/app/domain/auth/entity/AuthLoginAttempt.java
+++ b/app/src/main/java/com/authservice/app/domain/auth/entity/AuthLoginAttempt.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "auth_login_attempts")
@@ -20,7 +22,8 @@ public class AuthLoginAttempt {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
-	@Column(name = "id", nullable = false, updatable = false, columnDefinition = "BINARY(16)")
+	@Column(name = "id", nullable = false, updatable = false, columnDefinition = "char(36)")
+	@JdbcTypeCode(SqlTypes.CHAR)
 	private UUID id;
 
 	@Column(name = "login_id", nullable = false)

--- a/app/src/main/java/com/authservice/app/domain/auth/entity/MfaFactor.java
+++ b/app/src/main/java/com/authservice/app/domain/auth/entity/MfaFactor.java
@@ -12,6 +12,8 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "mfa_factors")
@@ -21,10 +23,12 @@ public class MfaFactor {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
-	@Column(name = "id", nullable = false, updatable = false, columnDefinition = "BINARY(16)")
+	@Column(name = "id", nullable = false, updatable = false, columnDefinition = "char(36)")
+	@JdbcTypeCode(SqlTypes.CHAR)
 	private UUID id;
 
-	@Column(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
+	@Column(name = "user_id", nullable = false, columnDefinition = "char(36)")
+	@JdbcTypeCode(SqlTypes.CHAR)
 	private UUID userId;
 
 	@Column(name = "factor_type", nullable = false)

--- a/app/src/main/java/com/authservice/app/domain/auth/sso/service/SsoSessionStore.java
+++ b/app/src/main/java/com/authservice/app/domain/auth/sso/service/SsoSessionStore.java
@@ -40,7 +40,7 @@ public class SsoSessionStore {
 	}
 
 	public Optional<SsoTicketPayload> consumeTicket(String ticket) {
-		return consume(TICKET_PREFIX + ticket, SsoTicketPayload.class);
+		return consume(new String[] {TICKET_PREFIX + ticket}, SsoTicketPayload.class);
 	}
 
 	public void saveSession(String sessionId, SsoSessionPayload payload, Instant expiresAt) {

--- a/app/src/main/java/com/authservice/app/security/AccessTokenCookieAuthFilter.java
+++ b/app/src/main/java/com/authservice/app/security/AccessTokenCookieAuthFilter.java
@@ -1,0 +1,90 @@
+package com.authservice.app.security;
+
+import com.auth.api.model.Principal;
+import com.auth.spi.TokenService;
+import com.authservice.app.domain.auth.sso.config.SsoProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 브라우저가 `ACCESS_TOKEN` 쿠키만 보내는 경우를 위한 보조 인증 필터입니다.
+ * Authorization 헤더가 없을 때만 쿠키를 읽어 SecurityContext를 채웁니다.
+ */
+public class AccessTokenCookieAuthFilter extends OncePerRequestFilter {
+
+	private final TokenService tokenService;
+	private final String accessTokenCookieName;
+	private final String sessionCookieName;
+
+	public AccessTokenCookieAuthFilter(TokenService tokenService, String accessTokenCookieName, SsoProperties ssoProperties) {
+		this.tokenService = tokenService;
+		this.accessTokenCookieName = accessTokenCookieName;
+		this.sessionCookieName = ssoProperties.getSession().getCookieName();
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+		try {
+			if (SecurityContextHolder.getContext().getAuthentication() == null
+				&& !hasAuthorizationHeader(request)
+				&& !hasSessionCookie(request)) {
+				extractAccessToken(request)
+					.map(tokenService::verifyAccessToken)
+					.ifPresent(this::setAuthentication);
+			}
+			filterChain.doFilter(request, response);
+		} catch (Exception ex) {
+			SecurityContextHolder.clearContext();
+			filterChain.doFilter(request, response);
+		}
+	}
+
+	private boolean hasAuthorizationHeader(HttpServletRequest request) {
+		String authorization = request.getHeader("Authorization");
+		return authorization != null && !authorization.isBlank();
+	}
+
+	private boolean hasSessionCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return false;
+		}
+		return Arrays.stream(cookies)
+			.anyMatch(cookie -> sessionCookieName.equals(cookie.getName()) && cookie.getValue() != null && !cookie.getValue().isBlank());
+	}
+
+	private java.util.Optional<String> extractAccessToken(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return java.util.Optional.empty();
+		}
+		return Arrays.stream(cookies)
+			.filter(cookie -> accessTokenCookieName.equals(cookie.getName()))
+			.map(Cookie::getValue)
+			.filter(value -> value != null && !value.isBlank())
+			.findFirst();
+	}
+
+	private void setAuthentication(Principal principal) {
+		List<GrantedAuthority> authorities = principal.getAuthorities().stream()
+			.filter(value -> value != null && !value.isBlank())
+			.map(SimpleGrantedAuthority::new)
+			.collect(Collectors.toList());
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(principal.getUserId(), null, authorities);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+}

--- a/app/src/main/java/com/authservice/app/security/AccessTokenCookieAuthFilterConfig.java
+++ b/app/src/main/java/com/authservice/app/security/AccessTokenCookieAuthFilterConfig.java
@@ -1,0 +1,20 @@
+package com.authservice.app.security;
+
+import com.auth.spi.TokenService;
+import com.authservice.app.domain.auth.sso.config.SsoProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AccessTokenCookieAuthFilterConfig {
+
+	@Bean
+	public AccessTokenCookieAuthFilter accessTokenCookieAuthFilter(
+		TokenService tokenService,
+		SsoProperties ssoProperties,
+		@Value("${AUTH_ACCESS_COOKIE_NAME:ACCESS_TOKEN}") String accessTokenCookieName
+	) {
+		return new AccessTokenCookieAuthFilter(tokenService, accessTokenCookieName, ssoProperties);
+	}
+}

--- a/app/src/main/java/com/authservice/app/security/AuthJwtTokenService.java
+++ b/app/src/main/java/com/authservice/app/security/AuthJwtTokenService.java
@@ -1,0 +1,155 @@
+package com.authservice.app.security;
+
+import com.auth.api.exception.AuthException;
+import com.auth.api.exception.AuthFailureReason;
+import com.auth.api.model.Principal;
+import com.auth.common.utils.Strings;
+import com.auth.spi.TokenService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.JwtParserBuilder;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * auth-service의 JWT 발급 구현체입니다.
+ * access token에는 issuer를 명시적으로 넣어 downstream이 발급 주체를 판별할 수 있게 합니다.
+ */
+public class AuthJwtTokenService implements TokenService {
+
+	private static final String KEY_ISSUER = "iss";
+	private static final String KEY_AUDIENCE = "aud";
+	private static final String KEY_TOKEN_TYPE = "token_type";
+	private static final String KEY_AUTHORITIES = "authorities";
+	private static final String KEY_ROLES = "roles";
+	private static final String TOKEN_TYPE_ACCESS = "access";
+	private static final String TOKEN_TYPE_REFRESH = "refresh";
+	private static final String ISSUER = "auth-service";
+
+	private final Key key;
+	private final String audience;
+	private final long accessSeconds;
+	private final long refreshSeconds;
+
+	public AuthJwtTokenService(String secret, String audience, long accessSeconds, long refreshSeconds) {
+		if (Strings.isBlank(secret)) {
+			throw new AuthException(AuthFailureReason.INVALID_INPUT, "auth.jwt.secret must not be blank");
+		}
+		if (Strings.isBlank(audience)) {
+			throw new AuthException(AuthFailureReason.INVALID_INPUT, "auth.jwt.audience must not be blank");
+		}
+		byte[] secretBytes = secret.getBytes(StandardCharsets.UTF_8);
+		if (secretBytes.length < 32) {
+			throw new AuthException(AuthFailureReason.INVALID_INPUT, "auth.jwt.secret must be at least 32 bytes for HS256");
+		}
+		this.key = Keys.hmacShaKeyFor(secretBytes);
+		this.audience = audience;
+		this.accessSeconds = accessSeconds;
+		this.refreshSeconds = refreshSeconds;
+	}
+
+	@Override
+	public String issueAccessToken(Principal principal) {
+		return buildToken(principal, accessSeconds, TOKEN_TYPE_ACCESS, true);
+	}
+
+	@Override
+	public String issueRefreshToken(Principal principal) {
+		return buildToken(principal, refreshSeconds, TOKEN_TYPE_REFRESH, false);
+	}
+
+	@Override
+	public Principal verifyAccessToken(String token) {
+		return parseAndToPrincipal(token, TOKEN_TYPE_ACCESS);
+	}
+
+	@Override
+	public Principal verifyRefreshToken(String token) {
+		return parseAndToPrincipal(token, TOKEN_TYPE_REFRESH);
+	}
+
+	private String buildToken(Principal principal, long ttlSeconds, String tokenType, boolean includeIssuer) {
+		Date issuedAt = new Date();
+		Date expiration = new Date(issuedAt.getTime() + (Math.max(ttlSeconds, 1) * 1000L));
+
+		Map<String, Object> claims = new HashMap<>(principal.getAttributes());
+		claims.remove(KEY_ISSUER);
+		if (!principal.getAuthorities().isEmpty()) {
+			claims.put(KEY_AUTHORITIES, principal.getAuthorities());
+			claims.put(KEY_ROLES, principal.getAuthorities());
+		}
+
+		JwtBuilder builder = Jwts.builder()
+			.setSubject(principal.getUserId())
+			.setAudience(audience)
+			.addClaims(claims)
+			.claim(KEY_TOKEN_TYPE, tokenType)
+			.setIssuedAt(issuedAt)
+			.setExpiration(expiration);
+
+		if (includeIssuer) {
+			builder.setIssuer(ISSUER);
+		}
+
+		return builder.signWith(key, SignatureAlgorithm.HS256).compact();
+	}
+
+	private Principal parseAndToPrincipal(String token, String expectedTokenType) {
+		try {
+			JwtParser parser = parserBuilder().build();
+			Claims claims = parser.parseClaimsJws(token).getBody();
+
+			String tokenType = claims.get(KEY_TOKEN_TYPE, String.class);
+			if (tokenType == null || !tokenType.equals(expectedTokenType)) {
+				throw new AuthException(AuthFailureReason.INVALID_TOKEN, "invalid token type");
+			}
+
+			String userId = claims.getSubject();
+			Map<String, Object> attributes = new HashMap<>(claims);
+			attributes.remove("sub");
+			attributes.remove("iat");
+			attributes.remove("exp");
+			attributes.remove(KEY_TOKEN_TYPE);
+			attributes.remove(KEY_AUTHORITIES);
+			attributes.remove(KEY_ROLES);
+			attributes.remove(KEY_ISSUER);
+
+			List<String> authorities = toAuthorities(claims.get(KEY_AUTHORITIES, Object.class));
+			if (authorities.isEmpty()) {
+				authorities = toAuthorities(claims.get(KEY_ROLES, Object.class));
+			}
+
+			return new Principal(userId, authorities, attributes);
+		} catch (AuthException ex) {
+			throw ex;
+		} catch (JwtException | IllegalArgumentException ex) {
+			throw new AuthException(AuthFailureReason.INVALID_TOKEN, "invalid/expired token", ex);
+		}
+	}
+
+	private JwtParserBuilder parserBuilder() {
+		return Jwts.parserBuilder().setSigningKey(key);
+	}
+
+	private List<String> toAuthorities(Object value) {
+		if (value instanceof List<?> list) {
+			return list.stream()
+				.filter(String.class::isInstance)
+				.map(String.class::cast)
+				.toList();
+		}
+		if (value instanceof String string) {
+			return List.of(string);
+		}
+		return List.of();
+	}
+}

--- a/app/src/main/java/com/authservice/app/security/AuthJwtTokenServiceConfig.java
+++ b/app/src/main/java/com/authservice/app/security/AuthJwtTokenServiceConfig.java
@@ -1,0 +1,26 @@
+package com.authservice.app.security;
+
+import com.auth.config.jwt.AuthJwtProperties;
+import com.auth.spi.TokenService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class AuthJwtTokenServiceConfig {
+
+	@Bean
+	@Primary
+	public TokenService tokenService(
+		AuthJwtProperties props,
+		@Value("${AUTH_JWT_AUDIENCE:block-service}") String audience
+	) {
+		return new AuthJwtTokenService(
+			props.getSecret(),
+			audience,
+			props.getAccessSeconds(),
+			props.getRefreshSeconds()
+		);
+	}
+}

--- a/app/src/main/java/com/authservice/app/security/SecurityConfig.java
+++ b/app/src/main/java/com/authservice/app/security/SecurityConfig.java
@@ -28,18 +28,21 @@ public class SecurityConfig {
 	private final SsoProperties ssoProperties;
 	private final SsoOAuth2SuccessHandler ssoOAuth2SuccessHandler;
 	private final SsoOAuth2FailureHandler ssoOAuth2FailureHandler;
+	private final AccessTokenCookieAuthFilter accessTokenCookieAuthFilter;
 
 	public SecurityConfig(AuthOncePerRequestFilter authFilter,
 		RestAuthHandlers.EntryPoint entryPoint, RestAuthHandlers.Denied denied,
 		SsoProperties ssoProperties,
 		SsoOAuth2SuccessHandler ssoOAuth2SuccessHandler,
-		SsoOAuth2FailureHandler ssoOAuth2FailureHandler) {
+		SsoOAuth2FailureHandler ssoOAuth2FailureHandler,
+		AccessTokenCookieAuthFilter accessTokenCookieAuthFilter) {
 		this.authFilter = authFilter;
 		this.entryPoint = entryPoint;
 		this.denied = denied;
 		this.ssoProperties = ssoProperties;
 		this.ssoOAuth2SuccessHandler = ssoOAuth2SuccessHandler;
 		this.ssoOAuth2FailureHandler = ssoOAuth2FailureHandler;
+		this.accessTokenCookieAuthFilter = accessTokenCookieAuthFilter;
 	}
 
 	@Bean
@@ -117,6 +120,7 @@ public class SecurityConfig {
 				.successHandler(ssoOAuth2SuccessHandler)
 				.failureHandler(ssoOAuth2FailureHandler)
 			)
+			.addFilterBefore(accessTokenCookieAuthFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();

--- a/app/src/main/resources/dev/application-dev_db.yml
+++ b/app/src/main/resources/dev/application-dev_db.yml
@@ -20,3 +20,5 @@ spring:
         format_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 100
+        type:
+          preferred_uuid_jdbc_type: CHAR

--- a/app/src/main/resources/prod/application-prod_db.yml
+++ b/app/src/main/resources/prod/application-prod_db.yml
@@ -19,3 +19,5 @@ jpa:
       format_sql: false
       use_sql_comments: false
       default_batch_fetch_size: 100
+      type:
+        preferred_uuid_jdbc_type: CHAR

--- a/app/src/test/java/com/authservice/app/security/AccessTokenCookieAuthFilterTest.java
+++ b/app/src/test/java/com/authservice/app/security/AccessTokenCookieAuthFilterTest.java
@@ -1,0 +1,90 @@
+package com.authservice.app.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.auth.api.model.Principal;
+import com.auth.spi.TokenService;
+import com.authservice.app.domain.auth.sso.config.SsoProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class AccessTokenCookieAuthFilterTest {
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void readsAccessTokenFromCookieWhenAuthorizationHeaderIsMissing() throws Exception {
+		TokenService tokenService = mock(TokenService.class);
+		when(tokenService.verifyAccessToken("access-token")).thenReturn(
+			new Principal("user-123", List.of("USER"))
+		);
+
+		AccessTokenCookieAuthFilter filter = new AccessTokenCookieAuthFilter(
+			tokenService,
+			"ACCESS_TOKEN",
+			new SsoProperties()
+		);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie("ACCESS_TOKEN", "access-token"));
+		HttpServletResponse response = new MockHttpServletResponse();
+		FilterChain chain = (req, res) -> { };
+
+		filter.doFilter(request, response, chain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+		assertThat(SecurityContextHolder.getContext().getAuthentication().getName()).isEqualTo("user-123");
+	}
+
+	@Test
+	void skipsCookieAuthWhenAuthorizationHeaderExists() throws Exception {
+		TokenService tokenService = mock(TokenService.class);
+		AccessTokenCookieAuthFilter filter = new AccessTokenCookieAuthFilter(
+			tokenService,
+			"ACCESS_TOKEN",
+			new SsoProperties()
+		);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer access-token");
+		request.setCookies(new Cookie("ACCESS_TOKEN", "access-token"));
+		HttpServletResponse response = new MockHttpServletResponse();
+		FilterChain chain = (req, res) -> { };
+
+		filter.doFilter(request, response, chain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+	}
+
+	@Test
+	void skipsCookieAuthWhenSessionCookieExists() throws Exception {
+		TokenService tokenService = mock(TokenService.class);
+		AccessTokenCookieAuthFilter filter = new AccessTokenCookieAuthFilter(
+			tokenService,
+			"ACCESS_TOKEN",
+			new SsoProperties()
+		);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(
+			new Cookie("sso_session", "session-id"),
+			new Cookie("ACCESS_TOKEN", "access-token")
+		);
+		HttpServletResponse response = new MockHttpServletResponse();
+		FilterChain chain = (req, res) -> { };
+
+		filter.doFilter(request, response, chain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+	}
+}

--- a/app/src/test/java/com/authservice/app/security/AuthJwtTokenServiceTest.java
+++ b/app/src/test/java/com/authservice/app/security/AuthJwtTokenServiceTest.java
@@ -1,0 +1,59 @@
+package com.authservice.app.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auth.api.model.Principal;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AuthJwtTokenServiceTest {
+
+	private static final String SECRET = "abcdefghijklmnopqrstuvwxyz12345678901234567890";
+	private static final Key KEY = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+
+	@Test
+	void accessTokenContainsIssuerAuthService() {
+		AuthJwtTokenService tokenService = new AuthJwtTokenService(SECRET, "block-service", 60, 120);
+		Principal principal = new Principal("46c45ce7-d50c-436e-9394-263941839cf7", List.of("USER"));
+
+		String token = tokenService.issueAccessToken(principal);
+
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKey(KEY)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+
+		assertThat(claims.getIssuer()).isEqualTo("auth-service");
+		assertThat(claims.getAudience()).isEqualTo("block-service");
+		assertThat(claims.getSubject()).isEqualTo(principal.getUserId());
+		assertThat(claims.get("token_type", String.class)).isEqualTo("access");
+		assertThat(claims.get("authorities")).isInstanceOf(List.class);
+		assertThat(claims.get("roles")).isInstanceOf(List.class);
+	}
+
+	@Test
+	void refreshTokenDoesNotNeedIssuerButStillVerifies() {
+		AuthJwtTokenService tokenService = new AuthJwtTokenService(SECRET, "block-service", 60, 120);
+		Principal principal = new Principal("46c45ce7-d50c-436e-9394-263941839cf7", List.of("USER"));
+
+		String token = tokenService.issueRefreshToken(principal);
+
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKey(KEY)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+
+		assertThat(claims.getIssuer()).isNull();
+		assertThat(claims.getAudience()).isEqualTo("block-service");
+		assertThat(claims.get("token_type", String.class)).isEqualTo("refresh");
+		assertThat(tokenService.verifyRefreshToken(token).getUserId()).isEqualTo(principal.getUserId());
+	}
+}

--- a/compose.auth-service.dev.yml
+++ b/compose.auth-service.dev.yml
@@ -10,8 +10,6 @@ services:
     environment:
       SERVER_PORT: ${SERVER_PORT:-8081}
     command: ["--spring.profiles.active=dev"]
-    ports:
-      - "${SERVER_PORT:-8081}:${SERVER_PORT:-8081}"
     depends_on:
       auth-mysql:
         condition: service_healthy

--- a/compose.auth-service.prod.yml
+++ b/compose.auth-service.prod.yml
@@ -8,8 +8,6 @@ services:
     env_file:
       - .env.prod
     command: ["--spring.profiles.active=prod"]
-    ports:
-      - "8081:8081"
     depends_on:
       auth-mysql:
         condition: service_healthy

--- a/db/migrations/2026-03-31_bind_uuid_columns_char36.sql
+++ b/db/migrations/2026-03-31_bind_uuid_columns_char36.sql
@@ -1,0 +1,13 @@
+-- auth-service UUID columns -> CHAR(36)
+-- 목적: JPA UUID 식별자를 MySQL CHAR(36) 컬럼으로 통일
+
+ALTER TABLE auth_accounts
+	MODIFY COLUMN id CHAR(36) NOT NULL,
+	MODIFY COLUMN user_id CHAR(36) NOT NULL;
+
+ALTER TABLE auth_login_attempts
+	MODIFY COLUMN id CHAR(36) NOT NULL;
+
+ALTER TABLE mfa_factors
+	MODIFY COLUMN id CHAR(36) NOT NULL,
+	MODIFY COLUMN user_id CHAR(36) NOT NULL;

--- a/db/migrations/2026-03-31_bind_uuid_columns_char36__rollback.sql
+++ b/db/migrations/2026-03-31_bind_uuid_columns_char36__rollback.sql
@@ -1,0 +1,12 @@
+-- rollback for 2026-03-31_bind_uuid_columns_char36.sql
+
+ALTER TABLE auth_accounts
+	MODIFY COLUMN id BINARY(16) NOT NULL,
+	MODIFY COLUMN user_id BINARY(16) NOT NULL;
+
+ALTER TABLE auth_login_attempts
+	MODIFY COLUMN id BINARY(16) NOT NULL;
+
+ALTER TABLE mfa_factors
+	MODIFY COLUMN id BINARY(16) NOT NULL,
+	MODIFY COLUMN user_id BINARY(16) NOT NULL;

--- a/docker/docker-compose.app.yml
+++ b/docker/docker-compose.app.yml
@@ -22,8 +22,6 @@ services:
       REDIS_SSL: ${REDIS_SSL:-false}
       SERVER_PORT: ${SERVER_PORT:-8081}
     command: ["--spring.profiles.active=${SPRING_PROFILES_ACTIVE}"]
-    ports:
-      - "${SERVER_PORT:-8081}:${SERVER_PORT:-8081}"
     depends_on:
       auth-mysql:
         condition: service_healthy

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,30 @@
+# Auth Database
+
+`auth-service`는 UUID 식별자를 `CHAR(36)`로 바인딩합니다.
+
+## Managed Tables
+
+- `auth_accounts`
+- `auth_login_attempts`
+- `mfa_factors`
+
+## UUID Binding
+
+- Java entity ID type: `java.util.UUID`
+- JPA/Hibernate JDBC type: `CHAR`
+- MySQL column type: `CHAR(36)`
+
+## Migration
+
+운영 DB가 과거 `BINARY(16)` 스키마라면 아래를 적용합니다.
+
+```bash
+./scripts/db/apply-bind-uuid-char36-prod.sh
+```
+
+롤백이 필요하면:
+
+```bash
+mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DB" \
+  < db/migrations/2026-03-31_bind_uuid_columns_char36__rollback.sql
+```

--- a/scripts/db/apply-bind-uuid-char36-prod.sh
+++ b/scripts/db/apply-bind-uuid-char36-prod.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="${1:-$PROJECT_ROOT/.env.prod}"
+MIGRATION_SQL="$PROJECT_ROOT/db/migrations/2026-03-31_bind_uuid_columns_char36.sql"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Env file not found: $ENV_FILE"
+  exit 1
+fi
+if [[ ! -f "$MIGRATION_SQL" ]]; then
+  echo "Migration SQL not found: $MIGRATION_SQL"
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+: "${MYSQL_HOST:?MYSQL_HOST is required}"
+: "${MYSQL_PORT:?MYSQL_PORT is required}"
+: "${MYSQL_DB:?MYSQL_DB is required}"
+: "${MYSQL_USER:?MYSQL_USER is required}"
+: "${MYSQL_PASSWORD:?MYSQL_PASSWORD is required}"
+
+MYSQL_BIN="$(command -v mysql || true)"
+if [[ -z "$MYSQL_BIN" && -x "/opt/homebrew/opt/mysql-client/bin/mysql" ]]; then
+  MYSQL_BIN="/opt/homebrew/opt/mysql-client/bin/mysql"
+fi
+if [[ -z "$MYSQL_BIN" ]]; then
+  echo "mysql client is required but not found"
+  exit 1
+fi
+
+echo "Applying migration to ${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DB}"
+"$MYSQL_BIN" \
+  --host="$MYSQL_HOST" \
+  --port="$MYSQL_PORT" \
+  --user="$MYSQL_USER" \
+  --password="$MYSQL_PASSWORD" \
+  "$MYSQL_DB" < "$MIGRATION_SQL"
+
+echo "Migration applied: bind auth UUID columns as CHAR(36)"


### PR DESCRIPTION
## 요약
- Auth-server README에 외부 `auth` 모듈 의존성을 명시했습니다.
- contract 레포의 Module Ecosystem 문서와 설명을 맞췄습니다.

## 변경 내용
- README에 현재 구현이 `auth` 모듈을 사용한다는 문구 추가
- contract 레포의 모듈 생태계 문서에 현재 적용 중인 auth 모듈 사용 상태 반영

## 검증
- `git diff --check` 통과

## 참고
- 관련 contract PR/커밋과 문서가 같은 책임 분리 기준을 따릅니다.